### PR TITLE
Allow the systemd services to restart endlessly

### DIFF
--- a/terraform/resources/ssh-key-agent-docker.service
+++ b/terraform/resources/ssh-key-agent-docker.service
@@ -2,6 +2,7 @@
 Description=ssh-key-agent
 After=docker.service
 Requires=docker.service
+StartLimitIntervalSec=0 # Allow infinite restarts
 [Service]
 Restart=on-failure
 ExecStartPre=-/usr/bin/mkdir -p /home/core/.ssh

--- a/terraform/resources/ssh-key-agent-docker.service
+++ b/terraform/resources/ssh-key-agent-docker.service
@@ -2,9 +2,9 @@
 Description=ssh-key-agent
 After=docker.service
 Requires=docker.service
-StartLimitIntervalSec=0 # Allow infinite restarts
 [Service]
 Restart=on-failure
+RestartSec=10
 ExecStartPre=-/usr/bin/mkdir -p /home/core/.ssh
 ExecStartPre=-/usr/bin/touch /home/core/.ssh/authorized_keys
 ExecStartPre=-/usr/bin/chown -R "core":"core" /home/core/.ssh

--- a/terraform/resources/ssh-key-agent-download.service
+++ b/terraform/resources/ssh-key-agent-download.service
@@ -3,11 +3,11 @@ Description=ssh-key-agent-download
 Wants=network-online.target
 After=network-online.target
 Before=ssh-key-agent.service
-StartLimitIntervalSec=0 # Allow infinite restarts
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=10
 ExecStart=-/usr/bin/wget -N -q -O "/opt/bin/ssh-key-agent" "${source}"
 ExecStart=-/usr/bin/chmod 755 /opt/bin/ssh-key-agent
 ExecStartPost=/bin/systemctl disable ssh-key-agent-download.service

--- a/terraform/resources/ssh-key-agent-download.service
+++ b/terraform/resources/ssh-key-agent-download.service
@@ -3,6 +3,7 @@ Description=ssh-key-agent-download
 Wants=network-online.target
 After=network-online.target
 Before=ssh-key-agent.service
+StartLimitIntervalSec=0 # Allow infinite restarts
 
 [Service]
 Type=oneshot

--- a/terraform/resources/ssh-key-agent.service
+++ b/terraform/resources/ssh-key-agent.service
@@ -2,9 +2,9 @@
 Description=ssh-key-agent
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0 # Allow infinite restarts
 [Service]
 Restart=on-failure
+RestartSec=10
 ExecStartPre=-/usr/bin/mkdir -p /home/core/.ssh
 ExecStartPre=-/usr/bin/touch /home/core/.ssh/authorized_keys
 ExecStartPre=-/usr/bin/chown -R "core":"core" /home/core/.ssh

--- a/terraform/resources/ssh-key-agent.service
+++ b/terraform/resources/ssh-key-agent.service
@@ -2,6 +2,7 @@
 Description=ssh-key-agent
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=0 # Allow infinite restarts
 [Service]
 Restart=on-failure
 ExecStartPre=-/usr/bin/mkdir -p /home/core/.ssh


### PR DESCRIPTION
We saw that in our on prem deployments, network might be unreachable for a few
seconds when systemd services are starting up. With the current approach,
ssh-key-agent services would restart 5 times (default) and then remain dead.
Since we rely on that service to pull our keys in and allow us access to the
host, let's disable the default interval and allow the service to restart
forever, until network is up and it can start fine.